### PR TITLE
Improved readability and fixed crashes

### DIFF
--- a/MRYIPCCenter.m
+++ b/MRYIPCCenter.m
@@ -1,172 +1,179 @@
 @import Foundation;
 #import "MRYIPCCenter.h"
 
-#define THROW(...) [self _throwException:[NSString stringWithFormat:__VA_ARGS__] fromMethod:_cmd]
+#define THROW(...) [self _throwException:[NSString stringWithFormat:__VA_ARGS__] \
+                              fromMethod:_cmd]
 
 @interface NSDistributedNotificationCenter : NSNotificationCenter
-+(instancetype)defaultCenter;
++ (instancetype)defaultCenter;
 @end
 
 @interface _MRYIPCMethod : NSObject
 @property (nonatomic, readonly) id target;
 @property (nonatomic, readonly) SEL selector;
--(instancetype)initWithTarget:(id)target selector:(SEL)selector;
+- (instancetype)initWithTarget:(id)target selector:(SEL)selector;
 @end
 
 @implementation _MRYIPCMethod
--(instancetype)initWithTarget:(id)target selector:(SEL)selector
-{
-	if ((self = [self init]))
-	{
-		_target = target;
-		_selector = selector;
-	}
-	return self;
+
+- (instancetype)initWithTarget:(id)target selector:(SEL)selector {
+    if (self = [self init]) {
+        _target = target;
+        _selector = selector;
+    }
+    return self;
 }
+
+
 @end
 
-@interface MRYIPCCenter ()
--(instancetype)initWithName:(NSString*)name;
--(void)_throwException:(NSString*)msg fromMethod:(SEL)method;
--(NSString*)_messageNameForSelector:(SEL)selector;
--(NSString*)_messageReplyNameForSelector:(SEL)selector uuid:(NSString*)uuid;
+@interface MRYCenter ()
+- (instancetype)initWithName:(NSString *)name;
+- (void)_throwException:(NSString *)msg fromMethod:(SEL)method;
+- (NSString *)_messageNameForSelector:(SEL)selector;
+- (NSString *)_messageReplyNameForSelector:(SEL)selector uuid:(NSString *)uuid;
 @end
 
-@implementation MRYIPCCenter
-{
-	NSDistributedNotificationCenter* _notificationCenter;
-	NSMutableDictionary<NSString*, _MRYIPCMethod*>* _methods;
+@implementation MRYCenter {
+    NSDistributedNotificationCenter *_notificationCenter;
+    NSMutableDictionary<NSString *, _MRYIPCMethod *> *_methods;
 }
 
-+(instancetype)centerNamed:(NSString*)name
-{
-	return [[self alloc] initWithName:name];
++ (instancetype)centerNamed:(NSString *)name {
+    return [[self alloc] initWithName:name];
 }
 
--(instancetype)initWithName:(NSString*)name
-{
-	if ((self = [self init]))
-	{
-		if (!name.length)
-			THROW(@"a center name must be supplied");
-		_centerName = name;
-		_notificationCenter = [NSDistributedNotificationCenter defaultCenter];
-		_methods = [NSMutableDictionary new];
-	}
-	return self;
+- (instancetype)initWithName:(NSString *)name {
+    if (self = [self init]) {
+        if (!name.length)
+            THROW(@"a center name must be supplied");
+        _centerName = name;
+        _notificationCenter = [NSDistributedNotificationCenter defaultCenter];
+        _methods = [NSMutableDictionary new];
+    }
+    return self;
 }
 
--(void)addTarget:(id)target action:(SEL)action
-{
-	if (!action || !strlen(sel_getName(action)))
-		THROW(@"method cannot be null");
-	if (!target)
-		THROW(@"target cannot be null");
-	
-	NSString* messageName = [self _messageNameForSelector:action];
-	if (_methods[messageName])
-		THROW(@"method already registered: %@", NSStringFromSelector(action));
-	
-	_MRYIPCMethod* method = [[_MRYIPCMethod alloc] initWithTarget:target selector:action];
-	_methods[messageName] = method;
+- (void)addTarget:(id)target action:(SEL)action {
+    if (!action || !strlen(sel_getName(action)))
+        THROW(@"method cannot be null");
+    if (!target)
+        THROW(@"target cannot be null");
 
-	[_notificationCenter addObserver:self selector:@selector(_messageReceived:) name:messageName object:nil];
+    NSString *messageName = [self _messageNameForSelector:action];
+    if (_methods[messageName])
+        THROW(@"method already registered: %@", NSStringFromSelector(action));
+
+    _MRYIPCMethod *method = [[_MRYIPCMethod alloc] initWithTarget:target
+                                                     selector:action];
+    _methods[messageName] = method;
+
+    [_notificationCenter addObserver:self
+                            selector:@selector(_messageReceived:)
+                                name:messageName
+                              object:nil];
 }
 
-//deprecated
--(void)registerMethod:(SEL)selector withTarget:(id)target
-{
-	[self addTarget:target action:selector];
+- (void)callExternalVoidMethod:(SEL)method withArguments:(NSDictionary *)args {
+    NSString *messageName = [self _messageNameForSelector:method];
+    NSDictionary *userInfo = args ? @{@"args" : args} : @{};
+    [_notificationCenter postNotificationName:messageName
+                                       object:nil
+                                     userInfo:userInfo];
 }
 
--(void)callExternalVoidMethod:(SEL)method withArguments:(NSDictionary*)args
-{
-	NSString* messageName = [self _messageNameForSelector:method];
-	NSDictionary* userInfo = args ? @{@"args" : args} : @{};
-	[_notificationCenter postNotificationName:messageName object:nil userInfo:userInfo];
+- (id)callExternalMethod:(SEL)method withArguments:(NSDictionary *)args {
+    __block id returnValue = nil;
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+    [self callExternalMethod:method withArguments:args completion:^(id ret) {
+        returnValue = ret;
+        dispatch_semaphore_signal(sema);
+    }];
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+    return returnValue;
 }
 
--(id)callExternalMethod:(SEL)method withArguments:(NSDictionary*)args
-{
-	__block id returnValue = nil;
-	dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-	[self callExternalMethod:method withArguments:args completion:^(id ret){
-		returnValue = ret;
-		dispatch_semaphore_signal(sema);
-	}];
-	dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
-	return returnValue;
+- (void)callExternalMethod:(SEL)method
+             withArguments:(NSDictionary *)args
+                completion:(void(^)(id))completionHandler {
+    NSString *replyUUID = [NSUUID UUID].UUIDString;
+    NSString *messageName = [self _messageNameForSelector:method];
+    NSString *replyMessageName = [self _messageReplyNameForSelector:method
+                                                               uuid:replyUUID];
+    __weak NSDistributedNotificationCenter *weakNotificationCenter = _notificationCenter;
+    NSOperationQueue *operationQueue = [NSOperationQueue new];
+    __block id observer = [_notificationCenter addObserverForName:replyMessageName
+                                                           object:nil
+                                                            queue:operationQueue
+                                                       usingBlock:^(NSNotification *notification) {
+        completionHandler(notification.userInfo[@"returnValue"]);
+        [weakNotificationCenter removeObserver:observer];
+        observer = nil;
+    }];
+
+    NSMutableDictionary *userInfo = [NSMutableDictionary new];
+    userInfo[@"replyUUID"] = replyUUID;
+    if (args)
+        userInfo[@"args"] = args;
+    [_notificationCenter postNotificationName:messageName
+                                       object:nil
+                                     userInfo:userInfo];
 }
 
--(void)callExternalMethod:(SEL)method withArguments:(NSDictionary*)args completion:(void(^)(id))completionHandler
-{
-	NSString* replyUUID = [NSUUID UUID].UUIDString;
-	NSString* messageName = [self _messageNameForSelector:method];
-	NSString* replyMessageName = [self _messageReplyNameForSelector:method uuid:replyUUID];
-	__weak NSDistributedNotificationCenter* weakNotificationCenter = _notificationCenter;
-	NSOperationQueue* operationQueue = [NSOperationQueue new];
-	__block id observer = [_notificationCenter addObserverForName:replyMessageName object:nil queue:operationQueue usingBlock:^(NSNotification* notification){
-		completionHandler(notification.userInfo[@"returnValue"]);
-		[weakNotificationCenter removeObserver:observer];
-		observer = nil;
-	}];
-	NSMutableDictionary* userInfo = [NSMutableDictionary new];
-	userInfo[@"replyUUID"] = replyUUID;
-	if (args)
-		userInfo[@"args"] = args;
-	[_notificationCenter postNotificationName:messageName object:nil userInfo:userInfo];
+- (NSString *)_messageNameForSelector:(SEL)selector {
+    return [NSString stringWithFormat:@"MRYCenter-%@-%@",
+            _centerName, NSStringFromSelector(selector)];
 }
 
--(NSString*)_messageNameForSelector:(SEL)selector
-{
-	return [NSString stringWithFormat:@"MRYIPCCenter-%@-%@", _centerName, NSStringFromSelector(selector)];
+- (NSString *)_messageReplyNameForSelector:(SEL)selector
+                                      uuid:(NSString *)uuid {
+    return [NSString stringWithFormat:@"MRYCenter-%@-%@-reply-%@",
+            _centerName, NSStringFromSelector(selector), uuid];
 }
 
--(NSString*)_messageReplyNameForSelector:(SEL)selector uuid:(NSString*)uuid
-{
-	return [NSString stringWithFormat:@"MRYIPCCenter-%@-%@-reply-%@", _centerName, NSStringFromSelector(selector), uuid];
+- (void)_messageReceived:(NSNotification*)notification {
+    NSString *messageName = notification.name;
+    _MRYIPCMethod *method = _methods[messageName];
+    if (!method)
+        THROW(@"unrecognised message: %@", messageName);
+
+    //call method:
+    NSMethodSignature *signature = [method.target methodSignatureForSelector:method.selector];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    invocation.target = method.target;
+    invocation.selector = method.selector;
+    NSDictionary *args = notification.userInfo[@"args"];
+    NSString *replyUUID = notification.userInfo[@"replyUUID"];
+    if (args)
+        [invocation setArgument:&args atIndex:2];
+    [invocation invoke];
+
+    // Send reply
+    if (replyUUID.length) {
+        __unsafe_unretained id weakReturnValue = nil;
+        if (strcmp(signature.methodReturnType, "v") != 0)
+            [invocation getReturnValue:&weakReturnValue];
+        id returnValue = weakReturnValue;
+        NSDictionary *replyDict = returnValue ? @{@"returnValue" : returnValue} : @{};
+        NSString *replyMessageName = [self _messageReplyNameForSelector:method.selector
+                                                                   uuid:replyUUID];
+        [_notificationCenter postNotificationName:replyMessageName
+                                           object:nil
+                                         userInfo:replyDict];
+    }
 }
 
--(void)_messageReceived:(NSNotification*)notification
-{
-	NSString* messageName = notification.name;
-	_MRYIPCMethod* method = _methods[messageName];
-	if (!method)
-		THROW(@"unrecognised message: %@", messageName);
-	
-	//call method:
-	NSMethodSignature* signature = [method.target methodSignatureForSelector:method.selector];
-	NSInvocation* invocation = [NSInvocation invocationWithMethodSignature:signature];
-	invocation.target = method.target;
-	invocation.selector = method.selector;
-	NSDictionary* args = notification.userInfo[@"args"];
-	NSString* replyUUID = notification.userInfo[@"replyUUID"];
-	if (args)
-		[invocation setArgument:&args atIndex:2];
-	[invocation invoke];
-
-	//send reply:
-	if (replyUUID.length)
-	{
-		__unsafe_unretained id weakReturnValue = nil;
-		if (strcmp(signature.methodReturnType, "v") != 0)
-			[invocation getReturnValue:&weakReturnValue];
-		id returnValue = weakReturnValue;
-		NSDictionary* replyDict = returnValue ? @{@"returnValue" : returnValue} : @{};
-		NSString* replyMessageName = [self _messageReplyNameForSelector:method.selector uuid:replyUUID];
-		[_notificationCenter postNotificationName:replyMessageName object:nil userInfo:replyDict];
-	}
+- (void)_throwException:(NSString *)msg fromMethod:(SEL)method {
+    NSString *reason = [NSString stringWithFormat:@"-[%@ %@] - %@",
+                        [self class], NSStringFromSelector(method), msg];
+    NSException *myException = [NSException exceptionWithName:@"MRYIPCException"
+                                                       reason:reason
+                                                     userInfo:nil];
+    @throw myException;
 }
 
--(void)_throwException:(NSString*)msg fromMethod:(SEL)method
-{
-	NSString* reason = [NSString stringWithFormat:@"-[%@ %@] - %@", [self class], NSStringFromSelector(method), msg];
-	NSException* myException = [NSException exceptionWithName:@"MRYIPCException" reason:reason userInfo:nil];
-	@throw myException;
+- (void)dealloc {
+    [_notificationCenter removeObserver:self];
 }
 
--(void)dealloc
-{
-	[_notificationCenter removeObserver:self];
-}
 @end

--- a/MRYIPCCenter.m
+++ b/MRYIPCCenter.m
@@ -98,18 +98,21 @@
                 completion:(void(^)(id))completionHandler {
     NSString *replyUUID = [NSUUID UUID].UUIDString;
     NSString *messageName = [self _messageNameForSelector:method];
-    NSString *replyMessageName = [self _messageReplyNameForSelector:method
-                                                               uuid:replyUUID];
-    __weak NSDistributedNotificationCenter *weakNotificationCenter = _notificationCenter;
-    NSOperationQueue *operationQueue = [NSOperationQueue new];
-    __block id observer = [_notificationCenter addObserverForName:replyMessageName
-                                                           object:nil
-                                                            queue:operationQueue
-                                                       usingBlock:^(NSNotification *notification) {
-        completionHandler(notification.userInfo[@"returnValue"]);
-        [weakNotificationCenter removeObserver:observer];
-        observer = nil;
-    }];
+
+    if (completionHandler) {
+        NSString *replyMessageName = [self _messageReplyNameForSelector:method
+                                                                   uuid:replyUUID];
+        __weak NSDistributedNotificationCenter *weakNotificationCenter = _notificationCenter;
+        NSOperationQueue *operationQueue = [NSOperationQueue new];
+        __block id observer = [_notificationCenter addObserverForName:replyMessageName
+                                                               object:nil
+                                                                queue:operationQueue
+                                                           usingBlock:^(NSNotification *notification) {
+            completionHandler(notification.userInfo[@"returnValue"]);
+            [weakNotificationCenter removeObserver:observer];
+            observer = nil;
+        }];
+    }
 
     NSMutableDictionary *userInfo = [NSMutableDictionary new];
     userInfo[@"replyUUID"] = replyUUID;

--- a/MRYIPCCenter.m
+++ b/MRYIPCCenter.m
@@ -89,7 +89,7 @@
         returnValue = ret;
         dispatch_semaphore_signal(sema);
     }];
-    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+    dispatch_semaphore_wait(sema, (int64_t)(4.0 * NSEC_PER_SEC));
     return returnValue;
 }
 


### PR DESCRIPTION
Hi,

Firstly, everyone has different code standards but I took the freedom to add some new lines to avoid the rather lengthy method calls among other to improve the readability.

If no completion handler was wanted in the asynchronous call, it would previously lead to a crash. That's solved.

Another crash would happen if using the synchronous approach where it would be waiting for the semaphore to fire forever (if no answer was retrieved). I added a time bound of four seconds, which should be plenty of time for the server to reply if it's working correctly.

Moreover, I suggest changing the names to more clearly mark the difference between the methods being asynchronous and synchronous, so like: `callExternalMethodAsync:` and `callExternalMethodSync:`, but that would obviously cause issues with projects already using the framework. Just a thought.