### PR TITLE
Change extrainst_ to use bash

### DIFF
--- a/layout/DEBIAN/extrainst_
+++ b/layout/DEBIAN/extrainst_
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 function finish() {
 	f="${1}"


### PR DESCRIPTION
* Using nonposix operations in a POSIX shell will break. This affects Procursus jailbreaks.